### PR TITLE
#18 completableDeferred initialization check

### DIFF
--- a/coroutinespermission/src/main/java/com/eazypermissions/coroutinespermission/PermissionManager.kt
+++ b/coroutinespermission/src/main/java/com/eazypermissions/coroutinespermission/PermissionManager.kt
@@ -35,7 +35,8 @@ class PermissionManager : BasePermissionManager() {
     private lateinit var completableDeferred: CompletableDeferred<PermissionResult>
 
     override fun onPermissionResult(permissionResult: PermissionResult) {
-        completableDeferred.complete(permissionResult)
+        if (::completableDeferred.isInitialized)
+            completableDeferred.complete(permissionResult)
     }
 
     companion object {
@@ -126,7 +127,7 @@ class PermissionManager : BasePermissionManager() {
 
     override fun onDestroy() {
         super.onDestroy()
-        if (completableDeferred.isActive) {
+        if (::completableDeferred.isInitialized && completableDeferred.isActive) {
             completableDeferred.cancel()
         }
     }


### PR DESCRIPTION
if checks added for the lateinit property completableDeffered. Fragment methods called in its lifecycle whether eazypermissions methods used or not, so it is possible that property stays not initialized